### PR TITLE
fix: update offsets for CS2 after patch

### DIFF
--- a/Data/Entity/Player.cs
+++ b/Data/Entity/Player.cs
@@ -95,6 +95,19 @@ public class Player : EntityBase
         if (gameProcess.Process == null)
             throw new ArgumentNullException(nameof(gameProcess.Process), "Process cannot be null.");
 
+        var aimPunchService = gameProcess.Process.Read<IntPtr>(AddressBase + Offsets.m_pAimPunchServices);
+        if (aimPunchService != IntPtr.Zero)
+        {
+            try
+            {
+                return gameProcess.Process.Read<Vector3>(aimPunchService + Offsets.m_vecCsViewPunchAngle);
+            }
+            catch (Exception)
+            {
+                // Fall back to legacy path if the service access fails
+            }
+        }
+
         var cacheAddress = AddressBase + Offsets.m_AimPunchCache;
         AimPunchCacheCount = gameProcess.Process.Read<int>(cacheAddress);
         var cacheData = gameProcess.Process.Read<IntPtr>(cacheAddress + 0x8);

--- a/Utils/Offsets.cs
+++ b/Utils/Offsets.cs
@@ -16,6 +16,8 @@ public abstract class Offsets
     public static int m_vecViewOffset;
     public static int m_AimPunchAngle;
     public static int m_AimPunchCache;
+    public static int m_pAimPunchServices;
+    public static int m_vecCsViewPunchAngle;
     public static int m_modelState;
     public static int m_pGameSceneNode;
     public static int m_fFlags;
@@ -96,6 +98,8 @@ public abstract class Offsets
                 sourceDataClient.clientdll.classes.C_BaseModelEntity.fields.m_vecViewOffset;
             destData.m_aimPunchAngle = sourceDataClient.clientdll.classes.C_CSPlayerPawn.fields.m_aimPunchAngle;
             destData.m_aimPunchCache = sourceDataClient.clientdll.classes.C_CSPlayerPawn.fields.m_aimPunchCache;
+            destData.m_pAimPunchServices = sourceDataClient.clientdll.classes.C_CSPlayerPawn.fields.m_pAimPunchServices;
+            destData.m_vecCsViewPunchAngle = sourceDataClient.clientdll.classes.CPlayer_CameraServices.fields.m_vecCsViewPunchAngle;
             destData.m_modelState = sourceDataClient.clientdll.classes.CSkeletonInstance.fields.m_modelState;
             destData.m_pGameSceneNode = sourceDataClient.clientdll.classes.C_BaseEntity.fields.m_pGameSceneNode;
             destData.m_iIDEntIndex = sourceDataClient.clientdll.classes.C_CSPlayerPawn.fields.m_iIDEntIndex;
@@ -153,6 +157,8 @@ public abstract class Offsets
         m_vecViewOffset = data.m_vecViewOffset;
         m_AimPunchAngle = data.m_aimPunchAngle;
         m_AimPunchCache = data.m_aimPunchCache;
+        m_pAimPunchServices = data.m_pAimPunchServices;
+        m_vecCsViewPunchAngle = data.m_vecCsViewPunchAngle;
         m_modelState = data.m_modelState;
         m_pGameSceneNode = data.m_pGameSceneNode;
         m_iIDEntIndex = data.m_iIDEntIndex;

--- a/Utils/OffsetsDTO/ClientDllDTO.cs
+++ b/Utils/OffsetsDTO/ClientDllDTO.cs
@@ -4147,6 +4147,7 @@ public class Fields
     public int m_aimPunchAngle { get; set; }
     public int m_aimPunchAngleVel { get; set; }
     public int m_aimPunchCache { get; set; }
+    public int m_pAimPunchServices { get; set; }
     public int m_aimPunchTickBase { get; set; }
     public int m_aimPunchTickFraction { get; set; }
     public int m_bHasFemaleVoice { get; set; }


### PR DESCRIPTION
**🎮 CS2 Update – Memory Offset Fix**

After the latest CS2 update, the game's memory offsets have changed, breaking the cheat.
🔧 This PR updates the offsets so the cheat works again after the latest patch.